### PR TITLE
Fix GNH Context and Reconciliation to allow build

### DIFF
--- a/GoodNeighborHouse.TimeCard.Data/Context/GNHContext.cs
+++ b/GoodNeighborHouse.TimeCard.Data/Context/GNHContext.cs
@@ -16,7 +16,7 @@ namespace GoodNeighborHouse.TimeCard.Data.Context
 		private readonly IDatabaseSet<Organization> _organizationsWrapper;
 		private readonly IDatabaseSet<Punch> _punchesWrapper;
 		private readonly IDatabaseSet<Volunteer> _volunteersWrapper;
-
+        private readonly IDatabaseSet<Reconciliation> _reconciliationsWrapper;
 		public GNHContext(DbContextOptions options, bool readOnly = false) : base(options)
 		{
 			_readOnly = readOnly;
@@ -24,6 +24,7 @@ namespace GoodNeighborHouse.TimeCard.Data.Context
 			_organizationsWrapper = DatabaseSetWrapper.CreateFrom(() => Organizations);
 			_punchesWrapper = DatabaseSetWrapper.CreateFrom(() => Punches);
 			_volunteersWrapper = DatabaseSetWrapper.CreateFrom(() => Volunteers);
+            _reconciliationsWrapper = DatabaseSetWrapper.CreateFrom(() => Reconciliations);
 		}
 
 #if DEBUG
@@ -37,10 +38,12 @@ namespace GoodNeighborHouse.TimeCard.Data.Context
 		public DbSet<Punch> Punches { get; set; }
 		public DbSet<Volunteer> Volunteers { get; set; }
 
+        public DbSet<Reconciliation> Reconciliations { get; set; }
 		IDatabaseSet<Department> IGNHContext.Departments => _departmentsWrapper;
 		IDatabaseSet<Organization> IGNHContext.Organizations => _organizationsWrapper;
 		IDatabaseSet<Punch> IGNHContext.Punches => _punchesWrapper;
 		IDatabaseSet<Volunteer> IGNHContext.Volunteers => _volunteersWrapper;
+        IDatabaseSet<Reconciliation> IGNHContext.Reconciliations => _reconciliationsWrapper;
 
 		public new void SaveChanges()
 		{

--- a/GoodNeighborHouse.TimeCard.Data/Context/GNHContext.cs
+++ b/GoodNeighborHouse.TimeCard.Data/Context/GNHContext.cs
@@ -16,7 +16,7 @@ namespace GoodNeighborHouse.TimeCard.Data.Context
 		private readonly IDatabaseSet<Organization> _organizationsWrapper;
 		private readonly IDatabaseSet<Punch> _punchesWrapper;
 		private readonly IDatabaseSet<Volunteer> _volunteersWrapper;
-        private readonly IDatabaseSet<Reconciliation> _reconciliationsWrapper;
+		private readonly IDatabaseSet<Reconciliation> _reconciliationsWrapper;
 		public GNHContext(DbContextOptions options, bool readOnly = false) : base(options)
 		{
 			_readOnly = readOnly;
@@ -24,7 +24,7 @@ namespace GoodNeighborHouse.TimeCard.Data.Context
 			_organizationsWrapper = DatabaseSetWrapper.CreateFrom(() => Organizations);
 			_punchesWrapper = DatabaseSetWrapper.CreateFrom(() => Punches);
 			_volunteersWrapper = DatabaseSetWrapper.CreateFrom(() => Volunteers);
-            _reconciliationsWrapper = DatabaseSetWrapper.CreateFrom(() => Reconciliations);
+			_reconciliationsWrapper = DatabaseSetWrapper.CreateFrom(() => Reconciliations);
 		}
 
 #if DEBUG
@@ -43,7 +43,7 @@ namespace GoodNeighborHouse.TimeCard.Data.Context
 		IDatabaseSet<Organization> IGNHContext.Organizations => _organizationsWrapper;
 		IDatabaseSet<Punch> IGNHContext.Punches => _punchesWrapper;
 		IDatabaseSet<Volunteer> IGNHContext.Volunteers => _volunteersWrapper;
-        IDatabaseSet<Reconciliation> IGNHContext.Reconciliations => _reconciliationsWrapper;
+		IDatabaseSet<Reconciliation> IGNHContext.Reconciliations => _reconciliationsWrapper;
 
 		public new void SaveChanges()
 		{

--- a/GoodNeighborHouse.TimeCard.Data/Entities/Reconciliation.cs
+++ b/GoodNeighborHouse.TimeCard.Data/Entities/Reconciliation.cs
@@ -24,6 +24,5 @@ namespace GoodNeighborHouse.TimeCard.Data.Entities
         //difference in milliseconds.
         [ForeignKey(nameof(PunchInId))] public virtual Punch PunchIn { get; set; }
         [ForeignKey(nameof(PunchOutId))] public virtual Punch PunchOut { get; set; }
-
     }
 }


### PR DESCRIPTION
Update GNH Context with Reconciliation properties.  Retyped the PushOut virtual class as the build would not compile as it originally was.  